### PR TITLE
Camera switch and recenter always returns to initial view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,7 +78,7 @@ function App() {
     // if the src is already loaded, recenter the camera
     if (normalizedSrc.every((src) => loadedUrlsRef.current.includes(src.url))) {
       setTimeout(() => {
-        viewerRef.current?.recenter();
+        viewerRef.current?.setDefaultView();
       }, 100);
     }
   }, [src]);

--- a/src/types/CameraRefs.ts
+++ b/src/types/CameraRefs.ts
@@ -3,6 +3,18 @@ import { Vector3 } from 'three';
 
 export type CameraRefs = {
   controls: React.MutableRefObject<CameraControls | null>;
+  defaults: CameraDefaults;
   position: React.MutableRefObject<Vector3 | null>;
   target: React.MutableRefObject<Vector3 | null>;
+};
+
+export type CameraDefaults = {
+  perspective: CameraDefaultRefs;
+  orthographic: CameraDefaultRefs
+};
+
+export type CameraDefaultRefs = {
+  position: React.MutableRefObject<Vector3 | null>;
+  target: React.MutableRefObject<Vector3 | null>;
+  zoom: React.MutableRefObject<number | null>;
 };

--- a/src/types/ViewerProps.ts
+++ b/src/types/ViewerProps.ts
@@ -7,4 +7,5 @@ export type ViewerProps = {
 
 export type ViewerRef = {
   recenter: () => void;
+  setDefaultView: () => void;
 };


### PR DESCRIPTION
Before this PR, camera recenter calls fitToBox (which means object sometimes shows side profile or back instead of initial front view). Also, switching between cameras adjusts position oddly. This PR changes this to always have camera switching and recenter return to an initial front view for the object.